### PR TITLE
removed rechercher from drawer navigation

### DIFF
--- a/Navigation/Navigation.js
+++ b/Navigation/Navigation.js
@@ -16,7 +16,8 @@ const DrawerNavigator = createDrawerNavigator(
         Search: {
             screen: SearchStackNavigator,
             navigationOptions: {
-                title: 'Recherche'
+                // title: 'Recherche',
+                drawerLabel: () => null
             }
         },
         History: {


### PR DESCRIPTION
Je pense qu'il est temps de faire ca... Surtout avec le nouvel onglet stats de delphine

Removed 'Rechercher' tab from navigator. You can access this screen from 'Accueil' though

Next?
- [ ] (Idea) Add forground round button to access camera screen in almost all screens and remove 'Acceuil' from navigator